### PR TITLE
fix: rename "everySenconds" to "everySeconds"

### DIFF
--- a/src/schedule.ts
+++ b/src/schedule.ts
@@ -74,7 +74,7 @@ const FunctionExpressions = {
    * Run the task every S seconds
    * @param {number} seconds
    */
-  everySenconds(seconds = 1) { return `*/${seconds} * * * * *` },
+  everySeconds(seconds = 1) { return `*/${seconds} * * * * *` },
   /**
    * Run the task every M minutes
    * @param {number} minutes


### PR DESCRIPTION
fixes a typo, [docs correctly reference `everySeconds`](https://elysiajs.com/plugins/cron.html#functions) while the package has a typo.